### PR TITLE
make MAB not the default and change the config option for it

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,7 +30,7 @@ Next, create a Sixpack configuration. A configuration must be created for sixpac
     redis_db: 15                            # DB number in redis
 
     full_response: True                     # Not In Use
-    disable_whiplash: True                  # Disable the whiplash/multi-armed bandit choice Algorithm
+    enable_whiplash: False                  # Disable the whiplash/multi-armed bandit choice Algorithm
 
     # The regex to match for robots
     robot_regex: $^|trivial|facebook|MetaURI|butterfly|google|amazon|goldfire|sleuth|xenu|msnbot|SiteUptime|Slurp|WordPress|ZIBB|ZyBorg|pingdom|bot|yahoo|slurp|java|fetch|spider|url|crawl|oneriot|abby|commentreader|twiceler

--- a/config.yml
+++ b/config.yml
@@ -6,7 +6,7 @@ redis_prefix: sxp
 redis_db: 15
 
 full_response: True
-disable_whiplash: True
+enable_whiplash: True
 
 robot_regex: $^|trivial|facebook|MetaURI|butterfly|google|amazon|goldfire|sleuth|xenu|msnbot|SiteUptime|Slurp|WordPress|ZIBB|ZyBorg|pingdom|bot|yahoo|slurp|java|fetch|spider|url|crawl|oneriot|abby|commentreader|twiceler
 ignored_ip_addresses: []

--- a/sixpack/models.py
+++ b/sixpack/models.py
@@ -255,13 +255,10 @@ class Experiment(object):
         return None
 
     def choose_alternative(self, client=None):
-        if cfg.get('disable_whiplash'):
-            return self._random_choice()
-
-        if random.random() < self.random_sample:
-            return self._random_choice()
-        else:
+        if cfg.get('enable_whiplash') and random.random() >= self.random_sample:
             return Alternative(self._whiplash(), self, self.redis)
+
+        return self._random_choice()
 
     def _random_choice(self):
         return random.choice(self.alternatives)


### PR DESCRIPTION
This is regarding our internal email where MAB is enabled by default, but that's not what most people will need or desire.

In any case, I've changed the `disable_whiplash` configuration to `enable_whiplash`, and modified the code for alternative choosing to be a bit more clear.

Perhaps this should be a test-level setting instead? Thats a separate issue I guess.

/cc'ing @jack7890 or my sixpack pull request will stay in limbo forever.
