### PR TITLE
find_or_404 should only catch ValueError.

### DIFF
--- a/sixpack/web.py
+++ b/sixpack/web.py
@@ -166,7 +166,7 @@ def find_or_404(experiment_name):
         if request.args.get('kpi'):
             exp.set_kpi(request.args.get('kpi'))
         return exp
-    except:
+    except ValueError:
         abort(404)
 
 


### PR DESCRIPTION
By catching all errors it makes it very hard to debug.  For example, if
the Redis service craps out in the middle of the request, a 404 will be
returned instead of a 500, which means the exception will be silently
ignored, and not being logged correctly.
