### PR TITLE
manifest: Fix missing setup.py

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,7 @@
 exclude sixpack/static/.webassets-cache *
 recursive-include sixpack/static *
 recursive-include sixpack/templates *
+include setup.py
 include *.rst
 include *.yml
 include *.txt


### PR DESCRIPTION
The setup.py isn't in the package and wasn't being included

Closes #91
