### PR TITLE
Add support to non-ascii characters on experiment description

### DIFF
--- a/sixpack/models.py
+++ b/sixpack/models.py
@@ -184,7 +184,11 @@ class Experiment(object):
             self.redis.hset(self.key(), 'description', description)
 
     def get_description(self):
-        return self.redis.hget(self.key(), 'description').decode("utf-8", "replace")
+        description = self.redis.hget(self.key(), 'description')
+        if description:
+            return description.decode("utf-8", "replace")
+        else:
+            return None
 
     def reset(self):
         self.delete()


### PR DESCRIPTION
When using non-ascii characters on the experiment description sixpack-web just don't display the entire experiment, the workaround is to delete the description with HDEL and then just use ascii characters on the description. But I would like to use non-ascii characters on the description of my experiments, so here is a one-line patch.
