### PR TITLE
Allow clients to choose an alternative

### DIFF
--- a/sixpack/models.py
+++ b/sixpack/models.py
@@ -296,13 +296,22 @@ class Experiment(object):
             self._sequential_ids[client.client_id] = id_
         return self._sequential_ids[client.client_id]
 
-    def get_alternative(self, client, dt=None):
+    def get_alternative(self, client, alternative=None, dt=None):
+        """Returns and records an alternative according to the following
+        precedence:
+          1. An existing alternative
+          2. A client-chosen alternative
+          3. A server-chosen alternative
+        """
         if self.is_archived():
             return self.control
 
         chosen_alternative = self.existing_alternative(client)
         if not chosen_alternative:
-            chosen_alternative, participate = self.choose_alternative(client=client)
+            if alternative:
+                chosen_alternative, participate = Alternative(alternative, self, self.redis), True
+            else:
+                chosen_alternative, participate = self.choose_alternative(client=client)
             if participate:
                 chosen_alternative.record_participation(client, dt=dt)
 

--- a/sixpack/server.py
+++ b/sixpack/server.py
@@ -129,6 +129,7 @@ class Sixpack(object):
         force = request.args.get('force')
         client_id = request.args.get('client_id')
         traffic_fraction = request.args.get('traffic_fraction', 1)
+        client_chosen_alt = request.args.get('alternative', None)
 
         if client_id is None or experiment_name is None or alts is None:
             return json_error({'message': 'missing arguments'}, request, 400)
@@ -154,7 +155,7 @@ class Sixpack(object):
             if request.args.get("datetime"):
                 dt = dateutil.parser.parse(request.args.get("datetime"))
             client = Client(client_id, self.redis)
-            alternative = experiment.get_alternative(client, dt=dt).name
+            alternative = experiment.get_alternative(client, alternative=client_chosen_alt, dt=dt).name
 
         resp = {
             'alternative': {

--- a/sixpack/test/alternative_choice_test.py
+++ b/sixpack/test/alternative_choice_test.py
@@ -39,3 +39,15 @@ class TestAlternativeChoice(unittest.TestCase):
         e.set_winner("three")
         # after a winner
         test_force()
+
+    def test_client_chosen_alternative(self):
+        alts = ["one", "two", "three"]
+        e = Experiment.find_or_create("client-chosen-alternative", alts, self.app.redis)
+
+        data = json.loads(self.client.get("/participate?experiment=client-chosen-alternative&alternatives=one&alternatives=two&alternatives=three&client_id=1&alternative=one").data)
+        self.assertEqual(data['alternative']['name'], 'one')
+        self.assertEqual(e.total_participants(), 1)
+
+        data = json.loads(self.client.get("/participate?experiment=client-chosen-alternative&alternatives=one&alternatives=two&alternatives=three&client_id=2&alternative=two").data)
+        self.assertEqual(data['alternative']['name'], 'two')
+        self.assertEqual(e.total_participants(), 2)


### PR DESCRIPTION
Useful for situations where you may not know if a test will be encountered until it's too late to rely on asynchronously choosing an alternative.

For example, when testing the behavior of a button, if `participate` is called when the button is setup, users that never click the button will dilute the results, thus requiring more participations to reach significance.
