### PR TITLE
Refactor core logic into api.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 hiredis==0.1.1
 redis==2.9.0
-mock==1.0b1
+mock==1.0.1
 Werkzeug==0.9.1
 PyYAML==3.10
 Flask==0.10

--- a/sixpack/__init__.py
+++ b/sixpack/__init__.py
@@ -1,1 +1,3 @@
 __version__ = '1.1.2'
+
+from .api import participate, convert

--- a/sixpack/api.py
+++ b/sixpack/api.py
@@ -1,0 +1,41 @@
+from models import Experiment, Alternative, Client
+from config import CONFIG as cfg
+
+
+def participate(experiment, alternatives, client_id,
+    force=None,
+    traffic_fraction=None,
+    alternative=None,
+    datetime=None,
+    redis=None):
+
+    exp = Experiment.find_or_create(experiment, alternatives, traffic_fraction=traffic_fraction, redis=redis)
+
+    alt = None
+    if force and force in alternatives:
+        alt = Alternative(force, exp, redis=redis)
+    elif not cfg.get('enabled', True):
+        alt = exp.control
+    elif exp.winner is not None:
+        alt = exp.winner
+    else:
+        client = Client(client_id, redis=redis)
+        alt = exp.get_alternative(client, alternative=alternative, dt=datetime)
+
+    return alt
+
+
+def convert(experiment, client_id,
+    kpi=None,
+    datetime=None,
+    redis=None):
+
+    exp = Experiment.find(experiment, redis=redis)
+
+    if cfg.get('enabled', True):
+        client = Client(client_id, redis=redis)
+        alt = exp.convert(client, dt=datetime, kpi=kpi)
+    else:
+        alt = exp.control
+
+    return alt

--- a/sixpack/test/alternative_choice_test.py
+++ b/sixpack/test/alternative_choice_test.py
@@ -15,7 +15,7 @@ class TestAlternativeChoice(unittest.TestCase):
         self.client = Client(self.app, BaseResponse)
 
     def test_bots_get_winner_otherwise_control(self):
-        e = Experiment.find_or_create("bots-get-winner", ["one", "two"], self.app.redis)
+        e = Experiment.find_or_create("bots-get-winner", ["one", "two"], redis=self.app.redis)
         # control at first
         for i in range(3):
             data = json.loads(self.client.get("/participate?experiment=bots-get-winner&alternatives=one&alternatives=two&user_agent=GoogleBot&client_id=rand").data)
@@ -28,7 +28,7 @@ class TestAlternativeChoice(unittest.TestCase):
 
     def test_force_param_always_wins(self):
         alts = ["one", "two", "three"]
-        e = Experiment.find_or_create("force-param-always-wins", alts, self.app.redis)
+        e = Experiment.find_or_create("force-param-always-wins", alts, redis=self.app.redis)
 
         def test_force():
             for f in alts:
@@ -42,7 +42,7 @@ class TestAlternativeChoice(unittest.TestCase):
 
     def test_client_chosen_alternative(self):
         alts = ["one", "two", "three"]
-        e = Experiment.find_or_create("client-chosen-alternative", alts, self.app.redis)
+        e = Experiment.find_or_create("client-chosen-alternative", alts, redis=self.app.redis)
 
         data = json.loads(self.client.get("/participate?experiment=client-chosen-alternative&alternatives=one&alternatives=two&alternatives=three&client_id=1&alternative=one").data)
         self.assertEqual(data['alternative']['name'], 'one')

--- a/sixpack/test/alternative_model_test.py
+++ b/sixpack/test/alternative_model_test.py
@@ -13,9 +13,9 @@ class TestAlternativeModel(unittest.TestCase):
         self.client_id = 381
 
     def test_key(self):
-        exp = Experiment('show-something', ['yes', 'no'], self.redis)
+        exp = Experiment('show-something', ['yes', 'no'], redis=self.redis)
 
-        alt = Alternative('yes', exp, self.redis)
+        alt = Alternative('yes', exp, redis=self.redis)
         key = alt.key()
         self.assertEqual(key, 'sxp:show-something:yes')
 
@@ -40,18 +40,18 @@ class TestAlternativeModel(unittest.TestCase):
         self.assertFalse(not_valid)
 
     def test_is_control(self):
-        exp = Experiment('trololo', ['yes', 'no'], self.redis)
+        exp = Experiment('trololo', ['yes', 'no'], redis=self.redis)
         exp.save()
 
-        alt = Alternative('yes', exp, self.redis)
+        alt = Alternative('yes', exp, redis=self.redis)
         self.assertTrue(alt.is_control())
         exp.delete()
 
     def test_experiment(self):
-        exp = Experiment('trololo', ['yes', 'no'], self.redis)
+        exp = Experiment('trololo', ['yes', 'no'], redis=self.redis)
         exp.save()
 
-        alt = Alternative('yes', exp, self.redis)
+        alt = Alternative('yes', exp, redis=self.redis)
         self.assertTrue(alt.is_control())
 
     def test_participant_count(self):

--- a/sixpack/test/api_test.py
+++ b/sixpack/test/api_test.py
@@ -1,0 +1,51 @@
+import unittest
+from mock import patch, Mock
+
+import sixpack
+from sixpack.models import Experiment, Alternative
+
+
+class TestApi(unittest.TestCase):
+
+    @patch.object(Experiment, "find_or_create")
+    def test_participate(self, mock_find_or_create):
+        exp = Experiment("test", ["no", "yes"], winner=None)
+        exp.get_alternative = Mock(return_value=Alternative("yes", exp))
+        mock_find_or_create.return_value = exp
+        alternative = sixpack.participate("test", ["no", "yes"], "id1")
+        self.assertEqual("yes", alternative.name)
+        self.assertEqual("test", alternative.experiment.name)
+
+    @patch.object(Experiment, "find_or_create")
+    def test_participate_with_forced_alternative(self, mock_find_or_create):
+        mock_find_or_create.return_value = Experiment("test", ["no", "yes"], winner=None)
+        alternative = sixpack.participate("test", ["no", "yes"], "id1", force="yes")
+        self.assertEqual("yes", alternative.name)
+
+    @patch.object(Experiment, "find_or_create")
+    def test_participate_with_client_chosen_alternative(self, mock_find_or_create):
+        exp = Experiment("test", ["no", "yes"], winner=None)
+        exp.get_alternative = Mock(return_value=Alternative("yes", exp))
+        mock_find_or_create.return_value = exp
+        alternative = sixpack.participate("test", ["no", "yes"], "id1", alternative="yes")
+        exp.get_alternative.assert_called_once()
+        self.assertEqual("yes", alternative.name)
+
+    @patch.object(Experiment, "find")
+    def test_convert(self, mock_find):
+        exp = Experiment("test", ["no", "yes"], winner=None)
+        exp.convert = Mock(return_value=Alternative("yes", exp))
+        mock_find.return_value = exp
+        alternative = sixpack.convert("test", "id1")
+        self.assertEqual("yes", alternative.name)
+        self.assertEqual("test", alternative.experiment.name)
+
+    @patch.object(Experiment, "find")
+    def test_convert_with_kpi(self, mock_find):
+        exp = Experiment("test", ["no", "yes"], winner=None)
+        exp.convert = Mock(return_value=Alternative("yes", exp))
+        mock_find.return_value = exp
+        alternative = sixpack.convert("test", "id1", kpi="goal1")
+        # TODO: we're not really asserting anything about the KPI
+        self.assertEqual("yes", alternative.name)
+        self.assertEqual("test", alternative.experiment.name)

--- a/sixpack/test/experiment_lua_test.py
+++ b/sixpack/test/experiment_lua_test.py
@@ -13,15 +13,15 @@ class TestExperimentLua(unittest.TestCase):
         self.app = create_app()
 
     def test_convert(self):
-        exp = Experiment('test-convert', ['1', '2'], self.app.redis)
-        client = Client("eric", self.app.redis)
+        exp = Experiment('test-convert', ['1', '2'], redis=self.app.redis)
+        client = Client("eric", redis=self.app.redis)
         exp.get_alternative(client)
         exp.convert(client)
         self.assertEqual(exp.total_conversions(), 1)
 
     def test_cant_convert_twice(self):
-        exp = Experiment('test-cant-convert-twice', ['1', '2'], self.app.redis)
-        client = Client("eric", self.app.redis)
+        exp = Experiment('test-cant-convert-twice', ['1', '2'], redis=self.app.redis)
+        client = Client("eric", redis=self.app.redis)
         alt = exp.get_alternative(client)
         exp.convert(client)
         self.assertEqual(exp.total_conversions(), 1)
@@ -37,13 +37,13 @@ class TestExperimentLua(unittest.TestCase):
         self.assertEqual(total_conversions, 1)
 
     def test_find_existing_conversion(self):
-        exp = Experiment('test-find-existing-conversion', ['1', '2'], self.app.redis)
-        client = Client("eric", self.app.redis)
+        exp = Experiment('test-find-existing-conversion', ['1', '2'], redis=self.app.redis)
+        client = Client("eric", redis=self.app.redis)
         alt = exp.get_alternative(client)
         exp.convert(client)
         alt2 = exp.existing_conversion(client)
         self.assertIsNotNone(alt2)
         self.assertTrue(alt.name == alt2.name)
-        client2 = Client("zack", self.app.redis)
+        client2 = Client("zack", redis=self.app.redis)
         alt3 = exp.existing_conversion(client2)
         self.assertIsNone(alt3)

--- a/sixpack/test/experiment_model_test.py
+++ b/sixpack/test/experiment_model_test.py
@@ -16,16 +16,16 @@ class TestExperimentModel(unittest.TestCase):
         self.redis = fakeredis.FakeStrictRedis()
         self.alternatives = ['yes', 'no']
 
-        self.exp_1 = Experiment('show-something-awesome', self.alternatives, self.redis)
-        self.exp_2 = Experiment('dales-lagunitas', ['dales', 'lagunitas'], self.redis)
-        self.exp_3 = Experiment('mgd-budheavy', ['mgd', 'bud-heavy'], self.redis)
+        self.exp_1 = Experiment('show-something-awesome', self.alternatives, redis=self.redis)
+        self.exp_2 = Experiment('dales-lagunitas', ['dales', 'lagunitas'], redis=self.redis)
+        self.exp_3 = Experiment('mgd-budheavy', ['mgd', 'bud-heavy'], redis=self.redis)
         self.exp_1.save()
         self.exp_2.save()
         self.exp_3.save()
 
     def test_constructor(self):
         with self.assertRaises(ValueError):
-            Experiment('not-enough-args', ['1'], self.redis)
+            Experiment('not-enough-args', ['1'], redis=self.redis)
 
     def test_save(self):
         pass
@@ -35,7 +35,7 @@ class TestExperimentModel(unittest.TestCase):
         self.assertEqual(control.name, 'yes')
 
     def test_created_at(self):
-        exp = Experiment('bench-press', ['joe', 'think'], self.redis)
+        exp = Experiment('bench-press', ['joe', 'think'], redis=self.redis)
         date = exp.created_at()
         self.assertIsNone(date)
         exp.save()
@@ -43,12 +43,12 @@ class TestExperimentModel(unittest.TestCase):
         self.assertTrue(isinstance(date, datetime))
 
     def test_get_alternative_names(self):
-        exp = Experiment('show-something', self.alternatives, self.redis)
+        exp = Experiment('show-something', self.alternatives, redis=self.redis)
         names = exp.get_alternative_names()
         self.assertEqual(sorted(self.alternatives), sorted(names))
 
     def test_is_new_record(self):
-        exp = Experiment('show-something-is-new-record', self.alternatives, self.redis)
+        exp = Experiment('show-something-is-new-record', self.alternatives, redis=self.redis)
         self.assertTrue(exp.is_new_record())
         exp.save()
         self.assertFalse(exp.is_new_record())
@@ -62,39 +62,39 @@ class TestExperimentModel(unittest.TestCase):
         pass
 
     def test_description(self):
-        exp = Experiment.find_or_create('never-gonna', ['give', 'you', 'up'], self.redis)
+        exp = Experiment.find_or_create('never-gonna', ['give', 'you', 'up'], redis=self.redis)
         self.assertEqual(exp.get_description(), None)
 
         exp.update_description('hallo')
         self.assertEqual(exp.get_description(), 'hallo')
 
     def test_change_alternatives(self):
-        exp = Experiment.find_or_create('never-gonna-x', ['let', 'you', 'down'], self.redis)
+        exp = Experiment.find_or_create('never-gonna-x', ['let', 'you', 'down'], redis=self.redis)
 
         with self.assertRaises(ValueError):
-            Experiment.find_or_create('never-gonna-x', ['let', 'you', 'down', 'give', 'you', 'up'], self.redis)
+            Experiment.find_or_create('never-gonna-x', ['let', 'you', 'down', 'give', 'you', 'up'], redis=self.redis)
 
         exp.delete()
 
-        Experiment.find_or_create('never-gonna-x', ['let', 'you', 'down', 'give', 'you', 'up'], self.redis)
+        Experiment.find_or_create('never-gonna-x', ['let', 'you', 'down', 'give', 'you', 'up'], redis=self.redis)
 
     def test_delete(self):
-        exp = Experiment('delete-me', self.alternatives, self.redis)
+        exp = Experiment('delete-me', self.alternatives, redis=self.redis)
         exp.save()
 
         exp.delete()
         with self.assertRaises(ValueError):
-            Experiment.find('delete-me', self.redis)
+            Experiment.find('delete-me', redis=self.redis)
 
     def test_leaky_delete(self):
-        exp = Experiment('delete-me-1', self.alternatives, self.redis)
+        exp = Experiment('delete-me-1', self.alternatives, redis=self.redis)
         exp.save()
 
-        exp2 = Experiment('delete', self.alternatives, self.redis)
+        exp2 = Experiment('delete', self.alternatives, redis=self.redis)
         exp2.save()
 
         exp2.delete()
-        exp3 = Experiment.find('delete-me-1', self.redis)
+        exp3 = Experiment.find('delete-me-1', redis=self.redis)
         self.assertEqual(exp3.get_alternative_names(), self.alternatives)
 
     def test_archive(self):
@@ -111,38 +111,38 @@ class TestExperimentModel(unittest.TestCase):
         self.assertFalse(self.exp_1.is_archived())
 
     def test_set_winner(self):
-        exp = Experiment('test-winner', ['1', '2'], self.redis)
+        exp = Experiment('test-winner', ['1', '2'], redis=self.redis)
         exp.set_winner('1')
         self.assertTrue(exp.winner is not None)
 
         exp.set_winner('1')
-        self.assertEqual(exp.winner, '1')
+        self.assertEqual(exp.winner.name, '1')
 
     def test_winner(self):
-        exp = Experiment.find_or_create('test-get-winner', ['1', '2'], self.redis)
+        exp = Experiment.find_or_create('test-get-winner', ['1', '2'], redis=self.redis)
         self.assertIsNone(exp.winner)
 
         exp.set_winner('1')
-        self.assertEqual(exp.winner, '1')
+        self.assertEqual(exp.winner.name, '1')
 
     def test_reset_winner(self):
-        exp = Experiment('show-something-reset-winner', self.alternatives, self.redis)
+        exp = Experiment('show-something-reset-winner', self.alternatives, redis=self.redis)
         exp.save()
         exp.set_winner('yes')
         self.assertTrue(exp.winner is not None)
-        self.assertEqual(exp.winner, 'yes')
+        self.assertEqual(exp.winner.name, 'yes')
 
         exp.reset_winner()
         self.assertIsNone(exp.winner)
 
     def test_winner_key(self):
-        exp = Experiment.find_or_create('winner-key', ['win', 'lose'], self.redis)
+        exp = Experiment.find_or_create('winner-key', ['win', 'lose'], redis=self.redis)
         self.assertEqual(exp._winner_key, "{0}:winner".format(exp.key()))
 
     def test_get_alternative(self):
-        client = Client(10, self.redis)
+        client = Client(10, redis=self.redis)
 
-        exp = Experiment.find_or_create('archived-control', ['w', 'l'], self.redis)
+        exp = Experiment.find_or_create('archived-control', ['w', 'l'], redis=self.redis)
         exp.archive()
 
         # should return control on archived test with no winner
@@ -185,72 +185,72 @@ class TestExperimentModel(unittest.TestCase):
         key_2 = self.exp_2.key()
         self.assertEqual(key_2, 'sxp:e:dales-lagunitas')
 
-        exp = Experiment('brews', ['mgd', 'bud-heavy'], self.redis)
+        exp = Experiment('brews', ['mgd', 'bud-heavy'], redis=self.redis)
         key_3 = exp.key()
         self.assertEqual(key_3, 'sxp:e:brews')
 
     def test_find(self):
-        exp = Experiment('crunches-situps', ['crunches', 'situps'], self.redis)
+        exp = Experiment('crunches-situps', ['crunches', 'situps'], redis=self.redis)
         exp.save()
 
         with self.assertRaises(ValueError):
-            Experiment.find('this-does-not-exist', self.redis)
+            Experiment.find('this-does-not-exist', redis=self.redis)
 
         try:
-            Experiment.find('crunches-situps', self.redis)
+            Experiment.find('crunches-situps', redis=self.redis)
         except:
             self.fail('known exp not found')
 
     def test_find_or_create(self):
         # should throw a ValueError if alters are invalid
         with self.assertRaises(ValueError):
-            Experiment.find_or_create('party-time', ['1'], self.redis)
+            Experiment.find_or_create('party-time', ['1'], redis=self.redis)
 
         with self.assertRaises(ValueError):
-            Experiment.find_or_create('party-time', ['1', '*****'], self.redis)
+            Experiment.find_or_create('party-time', ['1', '*****'], redis=self.redis)
 
         # should create a -NEW- experiment if experiment has never been used
         with self.assertRaises(ValueError):
-            Experiment.find('dance-dance', self.redis)
+            Experiment.find('dance-dance', redis=self.redis)
 
     def test_all(self):
         # there are three created in setUp()
-        all_of_them = Experiment.all(self.redis)
+        all_of_them = Experiment.all(redis=self.redis)
         self.assertEqual(len(all_of_them), 3)
 
-        exp_1 = Experiment('archive-this', ['archived', 'unarchive'], self.redis)
+        exp_1 = Experiment('archive-this', ['archived', 'unarchive'], redis=self.redis)
         exp_1.save()
 
-        all_again = Experiment.all(self.redis)
+        all_again = Experiment.all(redis=self.redis)
         self.assertEqual(len(all_again), 4)
 
         exp_1.archive()
-        all_archived = Experiment.all(self.redis)
+        all_archived = Experiment.all(redis=self.redis)
         self.assertEqual(len(all_archived), 3)
 
-        all_with_archived = Experiment.all(self.redis, False)
+        all_with_archived = Experiment.all(exclude_archived=False, redis=self.redis)
         self.assertEqual(len(all_with_archived), 4)
 
-        all_archived = Experiment.archived(self.redis)
+        all_archived = Experiment.archived(redis=self.redis)
         self.assertEqual(len(all_archived), 1)
 
     def test_load_alternatives(self):
-        exp = Experiment.find_or_create('load-alts-test', ['yes', 'no', 'call-me-maybe'], self.redis)
-        alts = Experiment.load_alternatives(exp.name, self.redis)
+        exp = Experiment.find_or_create('load-alts-test', ['yes', 'no', 'call-me-maybe'], redis=self.redis)
+        alts = Experiment.load_alternatives(exp.name, redis=self.redis)
         self.assertEqual(sorted(alts), sorted(['yes', 'no', 'call-me-maybe']))
 
     def test_differing_alternatives_fails(self):
-        exp = Experiment.find_or_create('load-differing-alts', ['yes', 'zack', 'PBR'], self.redis)
-        alts = Experiment.load_alternatives(exp.name, self.redis)
+        exp = Experiment.find_or_create('load-differing-alts', ['yes', 'zack', 'PBR'], redis=self.redis)
+        alts = Experiment.load_alternatives(exp.name, redis=self.redis)
         self.assertEqual(sorted(alts), sorted(['PBR', 'yes', 'zack']))
 
         with self.assertRaises(ValueError):
-            exp = Experiment.find_or_create('load-differing-alts', ['kyle', 'zack', 'PBR'], self.redis)
+            exp = Experiment.find_or_create('load-differing-alts', ['kyle', 'zack', 'PBR'], redis=self.redis)
 
     def _test_initialize_alternatives(self):
         # Should throw ValueError
         with self.assertRaises(ValueError):
-            Experiment.initialize_alternatives('n', ['*'], self.redis)
+            Experiment.initialize_alternatives('n', ['*'], redis=self.redis)
 
         # each item in list should be Alternative Instance
         alt_objs = Experiment.initialize_alternatives('n', ['1', '2', '3'])
@@ -271,49 +271,32 @@ class TestExperimentModel(unittest.TestCase):
         not_valid = Experiment.is_valid('&123name')
         self.assertFalse(not_valid)
 
-    def test_invalid_options(self):
-        opts = {'derp': 'ington'}
-        with self.assertRaises(ValueError):
-            Experiment.find_or_create('jay-fi', ['jay', 'fi'], self.redis, opts)
-
     def test_valid_options(self):
-        opts = {'traffic_fraction': 1}
-        Experiment.find_or_create('red-white', ['red', 'white'], self.redis, opts)
-
-        opts = {'traffic_fraction': 0}
-        Experiment.find_or_create('red-white', ['red', 'white'], self.redis, opts)
-
-        opts = {'traffic_fraction': 0.4}
-        Experiment.find_or_create('red-white', ['red', 'white'], self.redis, opts)
-
+        Experiment.find_or_create('red-white', ['red', 'white'], traffic_fraction=1, redis=self.redis)
+        Experiment.find_or_create('red-white', ['red', 'white'], traffic_fraction=0, redis=self.redis)
+        Experiment.find_or_create('red-white', ['red', 'white'], traffic_fraction=0.4, redis=self.redis)
 
     def test_invalid_traffic_fraction(self):
-        opts = {'traffic_fraction': 2}
         with self.assertRaises(ValueError):
-            Experiment.find_or_create('dist-2', ['dist', '2'], self.redis, opts)
+            Experiment.find_or_create('dist-2', ['dist', '2'], traffic_fraction=2, redis=self.redis)
 
-        opts = {'traffic_fraction': 101}
         with self.assertRaises(ValueError):
-            Experiment.find_or_create('dist-100', ['dist', '100'], self.redis, opts)
+            Experiment.find_or_create('dist-100', ['dist', '100'], traffic_fraction=101, redis=self.redis)
 
-        opts = {'traffic_fraction': 'x'}
         with self.assertRaises(ValueError):
-            Experiment.find_or_create('dist-100', ['dist', '100'], self.redis, opts)
+            Experiment.find_or_create('dist-100', ['dist', '100'], traffic_fraction="x", redis=self.redis)
 
     def test_valid_traffic_fractions_save(self):
         # test the hidden prop gets set
-        opts = {'traffic_fraction': 0.02}
-        exp = Experiment.find_or_create('dist-02', ['dist', '100'], self.redis, opts)
+        exp = Experiment.find_or_create('dist-02', ['dist', '100'], traffic_fraction=0.02, redis=self.redis)
         self.assertEqual(exp._traffic_fraction, 0.02)
 
-        opts = {'traffic_fraction': 0.4}
-        exp = Experiment.find_or_create('dist-100', ['dist', '100'], self.redis, opts)
+        exp = Experiment.find_or_create('dist-100', ['dist', '100'], traffic_fraction=0.4, redis=self.redis)
         self.assertEqual(exp._traffic_fraction, 0.40)
 
     # test is set in redis
     def test_traffic_fraction(self):
-        opts = {'traffic_fraction': 0.10}
-        exp = Experiment.find_or_create('d-test-10', ['d', 'c'], self.redis, opts)
+        exp = Experiment.find_or_create('d-test-10', ['d', 'c'], traffic_fraction=0.1, redis=self.redis)
         exp.save()
         self.assertEqual(exp.traffic_fraction, 0.1)
 
@@ -338,26 +321,26 @@ class TestExperimentModel(unittest.TestCase):
         self.assertFalse(ret)
 
     def test_set_kpi(self):
-        exp = Experiment.find_or_create('multi-kpi', ['kpi', '123'], self.redis)
+        exp = Experiment.find_or_create('multi-kpi', ['kpi', '123'], redis=self.redis)
         # We shouldn't beable to manually set a KPI. Only via web request
         with self.assertRaises(ValueError):
             exp.set_kpi('bananza')
 
         # simulate conversion via webrequest
-        client = Client(100, self.redis)
+        client = Client(100, redis=self.redis)
         # hack for disabling whiplash
         exp.random_sample = 1
 
         exp.get_alternative(client)
         exp.convert(client, None, 'bananza')
 
-        exp2 = Experiment.find_or_create('multi-kpi', ['kpi', '123'], self.redis)
+        exp2 = Experiment.find_or_create('multi-kpi', ['kpi', '123'], redis=self.redis)
         self.assertEqual(exp2.kpi, None)
         exp2.set_kpi('bananza')
         self.assertEqual(exp2.kpi, 'bananza')
 
     def test_add_kpi(self):
-        exp = Experiment.find_or_create('multi-kpi-add', ['asdf', '999'], self.redis)
+        exp = Experiment.find_or_create('multi-kpi-add', ['asdf', '999'], redis=self.redis)
         kpi = 'omg-pop'
 
         exp.add_kpi(kpi)
@@ -366,7 +349,7 @@ class TestExperimentModel(unittest.TestCase):
         exp.delete()
 
     def test_get_kpis(self):
-        exp = Experiment.find_or_create('multi-kpi-add', ['asdf', '999'], self.redis)
+        exp = Experiment.find_or_create('multi-kpi-add', ['asdf', '999'], redis=self.redis)
         kpis = ['omg-pop', 'zynga']
 
         exp.add_kpi(kpis[0])


### PR DESCRIPTION
This has a few benefits:
- You can use sixpack within a python app with `sixpack.participate(...)`
- It's a bit easier to test
- It paves the way to add programmatically accessible analysis APIs which I'm thinking maybe a good way to address stuff like https://github.com/seatgeek/sixpack/pull/112

@zackkitzmiller this isn't ready to merge (it's got tests, but I haven't actually tested it...), but would you mind taking a look?
