### PR TITLE
Fix insecure content warnings with HTTPS.

### DIFF
--- a/sixpack/templates/layout.html
+++ b/sixpack/templates/layout.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <link href='http://fonts.googleapis.com/css?family=Lato:100,300,400' rel='stylesheet' type='text/css'>
+    <link href='//fonts.googleapis.com/css?family=Lato:100,300,400' rel='stylesheet' type='text/css'>
     <meta charset="utf-8">
     <title>Sixpack</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">


### PR DESCRIPTION
Change the fonts.googleapis.com link in layout.html to be protocol-relative.

This fixes insecure content warnings from modern browsers when running sixpack-web over HTTPS.
