### PR TITLE
Fix on traffic_fraction with False as a value

### DIFF
--- a/sixpack/models.py
+++ b/sixpack/models.py
@@ -274,7 +274,7 @@ class Experiment(object):
         if not self._traffic_fraction:
             try:
                 self._traffic_fraction = float(self.redis.hget(self.key(), 'traffic_fraction'))
-            except TypeError:
+            except (TypeError, ValueError):
                 self._traffic_fraction = 1
         return self._traffic_fraction
 


### PR DESCRIPTION
When traffic_fraction is set with False as a value (i.e. when resetting an experiment), then the traffic_fraction method raises ValueError because it cannot be transformed to float.
