### PR TITLE
Do not check traffic fraction for update on every participation.

### DIFF
--- a/sixpack/server.py
+++ b/sixpack/server.py
@@ -126,7 +126,9 @@ class Sixpack(object):
         experiment_name = request.args.get('experiment')
         force = request.args.get('force')
         client_id = request.args.get('client_id')
-        traffic_fraction = float(request.args.get('traffic_fraction', 1))
+        traffic_fraction = request.args.get('traffic_fraction')
+        if traffic_fraction is not None:
+            traffic_fraction = float(traffic_fraction)
         prefetch = to_bool(request.args.get('prefetch', 'false'))
 
         if client_id is None or experiment_name is None or alts is None:

--- a/sixpack/test/experiment_model_test.py
+++ b/sixpack/test/experiment_model_test.py
@@ -23,6 +23,11 @@ class TestExperimentModel(unittest.TestCase):
         self.exp_2.save()
         self.exp_3.save()
 
+    def tearDown(self):
+        pipe = self.redis.pipeline()
+        pipe.flushdb()
+        pipe.execute()
+
     def test_constructor(self):
         with self.assertRaises(ValueError):
             Experiment('not-enough-args', ['1'], redis=self.redis)
@@ -269,12 +274,15 @@ class TestExperimentModel(unittest.TestCase):
         with self.assertRaises(ValueError):
             Experiment.find_or_create('dist-100', ['dist', '100'], traffic_fraction="x", redis=self.redis)
 
-    def test_changing_traffic_fraction_fails(self):
-        Experiment.find_or_create('red-white', ['red', 'white'], traffic_fraction=1, redis=self.redis)
+    def test_fail_when_changing_traffic(self):
+        Experiment.find_or_create('red-white', ['red', 'white'], traffic_fraction=0.8, redis=self.redis)
 
         with self.assertRaises(ValueError):
             Experiment.find_or_create('red-white', ['red', 'white'], traffic_fraction=0.4, redis=self.redis)
 
+    def test_dont_fail_when_participating_in_nondefault_traffic_experiment_without_traffic_param(self):
+        Experiment.find_or_create('red-white', ['red', 'white'], traffic_fraction=0.5, redis=self.redis)
+        Experiment.find_or_create('red-white', ['red', 'white'], redis=self.redis)
 
     def test_valid_traffic_fractions_save(self):
         # test the hidden prop gets set


### PR DESCRIPTION
If a participation is requested without a traffic fraction argument, the traffic fraction is no longer assumed to be 1. This caused requests to always fail for experiments with a traffic fraction lower than 1 without explicit argument.

Further, the server no longer defaults the request parameter "traffic_fraction" to 1 but simply leaves it at None. It's up to the model to default this value to 1 only when creating an new experiment.