### PR TITLE
Retrieve alternative for client id

### DIFF
--- a/sixpack/api.py
+++ b/sixpack/api.py
@@ -39,3 +39,16 @@ def convert(experiment, client_id,
         alt = exp.control
 
     return alt
+
+def alternative(experiment, client_id,
+    redis=None):
+
+    exp = Experiment.find(experiment, redis=redis)
+
+    if cfg.get('enabled', True):
+        client = Client(client_id, redis=redis)
+        alt = exp.existing_alternative(client)
+    else:
+        alt = None
+
+    return alt


### PR DESCRIPTION
Our use case requires us to be able to retrieve an alternative for a particular client id. The reason for that is that we are starting the A/B testing journey on the client however have to terminate it on the server. This means that we have to have some way of retrieving the alternative for a client id on the server in order to convert.

This pull request works for us at the moment, however before I add more specs etc, I want to make sure that this is something you guys feel could be merged. Or is our use case to much of an edge case?

Any feedback is very much appreciated.