### PR TITLE
Remove round from choose alternative

### DIFF
--- a/sixpack/models.py
+++ b/sixpack/models.py
@@ -332,7 +332,7 @@ class Experiment(object):
         return None
 
     def choose_alternative(self, client):
-        rnd = round(random.uniform(1, 0.01), 2)
+        rnd = random.random()
         if rnd >= self.traffic_fraction:
             self.exclude_client(client)
             return self.control, False


### PR DESCRIPTION
Rounding the random number generated at choose_alternative is excluding users who happen to get a random number greater to 0.990000 (rounded to 1.00)

traffic_allocation is 1 by default and the condition *if rnd >= self.traffic_fraction:* leads to roughly 1% of the users being excluded