### PR TITLE
Add support for non-destructive participate

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -96,6 +96,8 @@ In this example, red will always be returned. This is used for testing only, and
 
 ``traffic_fraction`` (optional) sixpack allows for limiting experiments to a subset of traffic. You can pass the percentage of traffic you'd like to expose the test to as a decimal number here. (``?traffic_fraction=0.10`` for 10%)
 
+``force_participation`` (optional) if the user isn't already participating in the experiment, do we record participation (default) or just tell you they're not participating (by returning ``''`` as the alternative name)? Useful when changing things in several parts of your site depending on which bucket a user's in, and you only want to count users who start on a particular page.
+
 
 Response
 --------

--- a/sixpack/api.py
+++ b/sixpack/api.py
@@ -7,7 +7,8 @@ def participate(experiment, alternatives, client_id,
     traffic_fraction=None,
     prefetch=False,
     datetime=None,
-    redis=None):
+    redis=None,
+    force_participation=True):
 
     exp = Experiment.find_or_create(experiment, alternatives, traffic_fraction=traffic_fraction, redis=redis)
 
@@ -20,7 +21,10 @@ def participate(experiment, alternatives, client_id,
         alt = exp.winner
     else:
         client = Client(client_id, redis=redis)
-        alt = exp.get_alternative(client, dt=datetime, prefetch=prefetch)
+        alt = exp.get_alternative(client, dt=datetime, prefetch=prefetch, participate_if_new=force_participation)
+
+        if alt is None:
+            alt = Alternative('', exp, redis=redis)
 
     return alt
 

--- a/sixpack/models.py
+++ b/sixpack/models.py
@@ -293,7 +293,7 @@ class Experiment(object):
             self._sequential_ids[client.client_id] = id_
         return self._sequential_ids[client.client_id]
 
-    def get_alternative(self, client, dt=None, prefetch=False):
+    def get_alternative(self, client, dt=None, prefetch=False, participate_if_new=True):
         """Returns and records an alternative according to the following
         precedence:
           1. An existing alternative
@@ -303,7 +303,7 @@ class Experiment(object):
             return self.control
 
         chosen_alternative = self.existing_alternative(client)
-        if not chosen_alternative:
+        if participate_if_new and not chosen_alternative:
             chosen_alternative, participate = self.choose_alternative(client)
             if participate and not prefetch:
                 chosen_alternative.record_participation(client, dt=dt)

--- a/sixpack/server.py
+++ b/sixpack/server.py
@@ -125,6 +125,7 @@ class Sixpack(object):
         alts = request.args.getlist('alternatives')
         experiment_name = request.args.get('experiment')
         force = request.args.get('force')
+        force_participation = to_bool(request.args.get('force_participation', 'true'))
         client_id = request.args.get('client_id')
         traffic_fraction = float(request.args.get('traffic_fraction', 1))
         prefetch = to_bool(request.args.get('prefetch', 'false'))
@@ -146,7 +147,8 @@ class Sixpack(object):
             try:
                 alt = participate(experiment_name, alts, client_id,
                                   force=force, traffic_fraction=traffic_fraction,
-                                  prefetch=prefetch, datetime=dt, redis=self.redis)
+                                  prefetch=prefetch, datetime=dt, redis=self.redis,
+                                  force_participation=force_participation)
             except ValueError as e:
                 return json_error({'message': str(e)}, request, 400)
 

--- a/sixpack/test/alternative_choice_test.py
+++ b/sixpack/test/alternative_choice_test.py
@@ -42,6 +42,37 @@ class TestAlternativeChoice(unittest.TestCase):
         # after a winner
         test_force()
 
+    def test_disabling_force_participation_does_not_record(self):
+        alts = ["one", "two", "three"]
+        e = Experiment.find_or_create("disabling-force-participation", alts, redis=self.app.redis)
+
+        c1_data = json.loads(self.client.get(
+            "/participate?experiment=disabling-force-participation&"
+            "alternatives=one&"
+            "alternatives=two&"
+            "alternatives=three&"
+            "client_id=rand_c1").data)
+
+        c2_data = json.loads(self.client.get(
+            "/participate?experiment=disabling-force-participation&"
+            "alternatives=one&"
+            "alternatives=two&"
+            "alternatives=three&"
+            "force_participation=false&"
+            "client_id=rand_c2").data)
+
+        self.assertEqual(c2_data['alternative']['name'], '')
+        self.assertNotEqual(c1_data['alternative']['name'], '')
+
+        c2_with_participation = json.loads(self.client.get(
+            "/participate?experiment=disabling-force-participation&"
+            "alternatives=one&"
+            "alternatives=two&"
+            "alternatives=three&"
+            "client_id=rand_c2").data)
+
+        self.assertEqual(c2_data['alternative']['name'], '')
+
     def test_uniform_choice(self):
 
         # test name: deterministic-1


### PR DESCRIPTION
This adds support for an optional `force_participation=[y|n]` option to `/participate` - if the value is `n`, then calling `/participate` on a user who's not currently participating in the experiment won't add them in, it'll just return `''` as the alternative name they've been assigned.

We use `sixpack` to A/B test multi-page funnels, but it's difficult to do so accurately now. Here's an example of this, and how this PR could fix it:

Let's say my funnel goes across three pages, `A -> B -> C`. Without this feature, my math gets screwed up by a user who just happens to go to page `B` first - since they've been added to the experimental population and might only get half the new funnel. What I'd like to do is call a normal `/participate` on page `A` to bucket the user, and then `/participate?force_participation=n&...` on pages `B` and `C` to get the bucket the user's been assigned to. Doing this means that if a user comes to page `B` first, they won't count as part of the experiment, and I can give them either my standard copy (if I choose to treat `''` the same as my control group), or something else even more boring.