### PR TITLE
Discard conversions from excluded clients when traffic_fraction < 1.

### DIFF
--- a/sixpack/models.py
+++ b/sixpack/models.py
@@ -218,6 +218,9 @@ class Experiment(object):
         return self.redis.hexists(self.key(), 'archived')
 
     def convert(self, client, dt=None, kpi=None):
+        if self.is_client_excluded(client):
+            raise ValueError('this client was not participating')
+
         alternative = self.existing_alternative(client)
         if not alternative:
             raise ValueError('this client was not participaing')

--- a/sixpack/test/experiment_model_test.py
+++ b/sixpack/test/experiment_model_test.py
@@ -346,3 +346,30 @@ class TestExperimentModel(unittest.TestCase):
         self.assertIn(kpis[0], ekpi)
         self.assertIn(kpis[1], ekpi)
         exp.delete()
+
+    def test_excluded_client(self):
+        # need proper redis to register the msetbit script
+        import sixpack.db
+
+        e = Experiment.find_or_create('excluded-client', ['option-a', 'option-b'], redis=sixpack.db.REDIS)
+
+        # force participate 1 proper client on the control alternative
+        cnil = Client("cnil", redis=sixpack.db.REDIS)
+        e.control.record_participation(cnil)
+        e.convert(cnil)
+
+        # exclude client, gets control alternative & try to convert
+        c = Client("c", redis=sixpack.db.REDIS)
+        e.exclude_client(c)
+
+        self.assertTrue(e.control == e.get_alternative(c))
+        try:
+            e.convert(c)
+        except ValueError, ve:
+            pass
+
+        # confidence interval should be 0, throws an exception
+        self.assertEqual(e.control.confidence_interval(), 0)
+        # participation & completed count should be 1
+        self.assertEqual(e.control.participant_count(), 1)
+        self.assertEqual(e.control.completed_count(), 1)


### PR DESCRIPTION
When traffic_fraction is < 1, some clients get the control alternative.
The participations of these excluded clients are not recorded to redis.
When there is a conversion request for an excluded client, the conversion
is not discarded and recorded to redis. When there are a couple of these
conversions by excluded clients, the number of completed conversions
becomes bigger than the number of participants, which should never be
possible. The computation of the confidence_interval relies on this
assumption and fails when the completed_count becomes bigger than
participant_count.

The solution is to discard the conversions of excluded clients as well.

Fixes #166 