### PR TITLE
Display the number of clients that were excluded from the experiment on the dashboard.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ PyYAML==3.10
 Flask==0.10
 Flask-SeaSurf==0.1.13
 Flask-Assets==0.8
-fakeredis==0.3.0
+fakeredis==0.4.0
 decorator==3.3.2
 jsmin==2.0.2-1
 python-dateutil==1.5

--- a/sixpack/models.py
+++ b/sixpack/models.py
@@ -50,6 +50,7 @@ class Experiment(object):
             'alternatives': [],
             'created_at': self.created_at,
             'traffic_fraction': self.traffic_fraction,
+            'excluded_clients': self.excluded_clients(),
             'total_participants': self.total_participants(),
             'total_conversions': self.total_conversions(),
             'description': self.description,
@@ -317,6 +318,10 @@ class Experiment(object):
     def is_client_excluded(self, client):
         key = _key("e:{0}:excluded".format(self.name))
         return self.redis.getbit(key, self.sequential_id(client))
+
+    def excluded_clients(self):
+        key = _key("e:{0}:excluded".format(self.name))
+        return self.redis.bitcount(key)
 
     def existing_alternative(self, client):
         if self.is_client_excluded(client):

--- a/sixpack/templates/dashboard.html
+++ b/sixpack/templates/dashboard.html
@@ -70,7 +70,7 @@
     <% if (experiment.description) { %>
       <div class="desc"><%= experiment.pretty_description %></div>
     <% } %>
-    <div class="created-at">created: <%= experiment.created_at %> | traffic fraction: <%= experiment.traffic_fraction %></div>
+    <div class="created-at">created: <%= experiment.created_at %> | traffic fraction: <%= experiment.traffic_fraction %> (<%= experiment.excluded_clients %> excluded clients)</div>
 
   </div>
   <div class="clearfix"></div>

--- a/sixpack/test/experiment_model_test.py
+++ b/sixpack/test/experiment_model_test.py
@@ -346,3 +346,13 @@ class TestExperimentModel(unittest.TestCase):
         self.assertIn(kpis[0], ekpi)
         self.assertIn(kpis[1], ekpi)
         exp.delete()
+
+    def test_excluded_clients(self):
+        e = Experiment.find_or_create('count-excluded-clients', ['red', 'blue'], redis=self.redis)
+
+        for i in range(10):
+            c = Client("c-%d" % i, self.redis)
+            e.exclude_client(c)
+
+            # there is a very small chance that a client was not excluded.
+            self.assertEqual(e.excluded_clients(), i + 1)


### PR DESCRIPTION
This PR adds a short function (with a test) to count the number of clients that were excluded from an experiment with traffic fraction lower than 1. That number is added to the dashboard page, right next to the traffic fraction.