### PR TITLE
Catch ValueError during g_stat calculation

### DIFF
--- a/sixpack/models.py
+++ b/sixpack/models.py
@@ -684,7 +684,7 @@ class Alternative(object):
                         +   control_conversions * log(control_conversions / expected_control_conversions) \
                         +   control_failures * log(control_failures / expected_control_failures))
 
-        except ZeroDivisionError:
+        except (ValueError, ZeroDivisionError):
             return 0
 
         return round(g_stat, 2)


### PR DESCRIPTION
There can be cases where the conversions for a given alternative are zero, resulting in a math domain error when taking the log of the value.

@zackkitzmiller Please review. I haven't deployed this, but I've tested it using a test script that simulates the issue.