### PR TITLE
Fix early bailout in existing_alternative for excluded clients

### DIFF
--- a/sixpack/models.py
+++ b/sixpack/models.py
@@ -331,7 +331,7 @@ class Experiment(object):
 
     def existing_alternative(self, client):
         if self.is_client_excluded(client):
-            None
+            return None
 
         alts = self.get_alternative_names()
         keys = [_key("p:{0}:{1}:all".format(self.name, alt)) for alt in alts]

--- a/sixpack/test/experiment_model_test.py
+++ b/sixpack/test/experiment_model_test.py
@@ -383,6 +383,7 @@ class TestExperimentModel(unittest.TestCase):
         e.exclude_client(c)
 
         self.assertTrue(e.control == e.get_alternative(c))
+        self.assertTrue(None == e.existing_alternative(c))
         with self.assertRaises(ValueError):
             e.convert(c)
 


### PR DESCRIPTION
Also added an additional assert to the excluded client test that verifies excluded clients have no existing alternative even after a call to `Experiment.get_alternative`.