### PR TITLE
add the ability to participate user into bucket

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -88,6 +88,8 @@ Arguments
 
 ``ip_address`` (optional) ip address of user making a request. Used for bot detection.
 
+``bucket`` (optional) name of the alternative you want to choose for participant.
+
 ``force`` (optional) force a specific alternative to be returned, example::
 
     $ curl http://localhost:5000/participate?experiment=button_color&alternatives=red&alternatives=blue&force=red&client_id=12345678-1234-5678-1234-567812345678

--- a/sixpack/api.py
+++ b/sixpack/api.py
@@ -4,6 +4,7 @@ from config import CONFIG as cfg
 
 def participate(experiment, alternatives, client_id,
     force=None,
+    bucket=None,
     traffic_fraction=None,
     prefetch=False,
     datetime=None,
@@ -20,7 +21,7 @@ def participate(experiment, alternatives, client_id,
         alt = exp.winner
     else:
         client = Client(client_id, redis=redis)
-        alt = exp.get_alternative(client, dt=datetime, prefetch=prefetch)
+        alt = exp.get_alternative(client, dt=datetime, prefetch=prefetch, force=bucket)
 
     return alt
 

--- a/sixpack/models.py
+++ b/sixpack/models.py
@@ -297,7 +297,7 @@ class Experiment(object):
             self._sequential_ids[client.client_id] = id_
         return self._sequential_ids[client.client_id]
 
-    def get_alternative(self, client, dt=None, prefetch=False):
+    def get_alternative(self, client, dt=None, prefetch=False, force=None):
         """Returns and records an alternative according to the following
         precedence:
           1. An existing alternative
@@ -311,7 +311,7 @@ class Experiment(object):
 
         chosen_alternative = self.existing_alternative(client)
         if not chosen_alternative:
-            chosen_alternative, participate = self.choose_alternative(client)
+            chosen_alternative, participate = self.choose_alternative(client, force=force)
             if participate and not prefetch:
                 chosen_alternative.record_participation(client, dt=dt)
 
@@ -342,7 +342,11 @@ class Experiment(object):
 
         return None
 
-    def choose_alternative(self, client):
+    def choose_alternative(self, client, force=None):
+        if force:
+            alternative = self.alternatives[self.get_alternative_names().index(force)]
+            return alternative, True
+
         rnd = random.random()
         if rnd >= self.traffic_fraction:
             self.exclude_client(client)

--- a/sixpack/server.py
+++ b/sixpack/server.py
@@ -124,6 +124,7 @@ class Sixpack(object):
     def on_participate(self, request):
         alts = request.args.getlist('alternatives')
         experiment_name = request.args.get('experiment')
+        bucket = request.args.get('bucket')
         force = request.args.get('force')
         client_id = request.args.get('client_id')
         traffic_fraction = request.args.get('traffic_fraction')
@@ -147,7 +148,7 @@ class Sixpack(object):
         else:
             try:
                 alt = participate(experiment_name, alts, client_id,
-                                  force=force, traffic_fraction=traffic_fraction,
+                                  force=force, bucket=bucket, traffic_fraction=traffic_fraction,
                                   prefetch=prefetch, datetime=dt, redis=self.redis)
             except ValueError as e:
                 return json_error({'message': str(e)}, request, 400)

--- a/sixpack/test/api_test.py
+++ b/sixpack/test/api_test.py
@@ -23,6 +23,20 @@ class TestApi(unittest.TestCase):
         alternative = participate("test", ["no", "yes"], "id1", force="yes")
         self.assertEqual("yes", alternative.name)
 
+    @patch.object(Alternative, "record_participation")
+    @patch.object(Experiment, "find_or_create")
+    def test_participate_with_bucket(self, mock_find_or_create, mock_record_participation):
+        exp = Experiment("test", ["no", "yes"], winner=None)
+        exp.is_archived = Mock(return_value=False)
+        exp.existing_alternative = Mock(return_value=False)
+        exp.is_client_excluded = Mock(return_value=False)
+        mock_find_or_create.return_value = exp
+
+        mock_record_participation.return_value = Alternative("no", exp)
+
+        alternative = participate("test", ["no", "yes"], "id1", bucket="no")
+        self.assertEqual("no", alternative.name)
+
     @patch.object(Experiment, "find")
     def test_convert(self, mock_find):
         exp = Experiment("test", ["no", "yes"], winner=None)


### PR DESCRIPTION
Replaces: https://github.com/seatgeek/sixpack/pull/170 as the guy who opened the PR is away. So there are no merge conflicts anymore, fixed the test and we can move forward.

My understanding of what we originally wanted though this change, by reading the code, was a way to force a user into an alternative but not bypass any other part of the system. We want to record the participation and force. The example on the original PR (as my understand goes) is more of a multi-part experiment where:

1. In experiment one I receive bucket one.
2. In experiment two I can then use the bucket from experiment one to determine which bucket I want to get into.
3. I can, as the expirment runner, convert each experiment individually