### PR TITLE
Add a configuration value to disable csrf

### DIFF
--- a/sixpack/config.py
+++ b/sixpack/config.py
@@ -30,6 +30,7 @@ else:
         'ignored_ip_addresses':os.environ.get('SIXPACK_CONFIG_IGNORE_IPS', "").split(","),
         'asset_path':os.environ.get('SIXPACK_CONFIG_ASSET_PATH', "gen"),
         'secret_key':os.environ.get('SIXPACK_CONFIG_SECRET', 'temp'),
+        'csrf_disable':os.environ.get('SIXPACK_CONFIG_CSRF_DISABLE', False)
     }
 
     if 'SIXPACK_CONFIG_REDIS_SENTINELS' in os.environ:

--- a/sixpack/web.py
+++ b/sixpack/web.py
@@ -17,6 +17,8 @@ import utils
 import re
 
 app = Flask(__name__)
+app.config['CSRF_DISABLE'] = cfg.get('csrf_disable', False)
+
 csrf = SeaSurf(app)
 
 js = Bundle('js/vendor/jquery.js', 'js/vendor/d3.js',


### PR DESCRIPTION
At Acquia, we would like to call some of the functionality in sixpack web using scripts (treating sixpack web as an admin api). The current csrf provisions prevent us from doing this in an easy way.

To solve this, we added a configuration option that gets passed directly so SeaSurf to disable the csrf functionality. The default value is false, so csrf is not disable when the setting is not set.