### PR TITLE
Pin gunicorn and gevent

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,5 +15,5 @@ closure==20121212
 Flask-DebugToolbar==0.7.1
 Markdown==2.3.1
 python-coveralls==2.4.3
-gunicorn
-gevent
+gunicorn>=17.5,<=19.4.1
+gevent==1.0.2


### PR DESCRIPTION
Tested in production with 17.5 and 19.4, working locally with a range of those versions.