### PR TITLE
Weighted Alternatives allocation

### DIFF
--- a/sixpack/test/weights_test.py
+++ b/sixpack/test/weights_test.py
@@ -1,0 +1,46 @@
+import unittest
+
+import sixpack
+from sixpack.models import Experiment
+
+
+class TestWeights(unittest.TestCase):
+
+    def test_uniform(self):
+        exp = Experiment("test", ["no", "yes"])
+        self.assertFalse(exp.is_weighted())
+        for alternative in exp.alternatives:
+            self.assertIsNone(alternative.weight)
+
+    def test_weighted(self):
+        exp = Experiment("test", ["no:70", "yes:30"])
+        self.assertTrue(exp.is_weighted())
+        for alternative in exp.alternatives:
+            self.assertIsNotNone(alternative.weight)
+            self.assertIsInstance(alternative.weight, int)
+            
+    def test_weighted_multi(self):
+        exp = Experiment("test", ["no:50", "yes:25", "maybe:25"])
+        self.assertTrue(exp.is_weighted())
+        for alternative in exp.alternatives:
+            self.assertIsNotNone(alternative.weight)
+            self.assertIsInstance(alternative.weight, int)
+
+    def test_wrong_weights(self):
+        exp = Experiment("test", ["no:70", "yes:20"])
+        self.assertFalse(exp.is_weighted())
+        exp = Experiment("test", ["no:70", "yes:40"])
+        self.assertFalse(exp.is_weighted())
+
+    def test_choices(self):
+        exp = Experiment("test", ["no:70", "yes:30"], traffic_fraction=1)
+        stats = {}
+        N = 100000
+        for i in range(N):
+            a,_ = exp.choose_alternative("abc")
+            stats[a.name] = stats.get(a.name,0) + 1
+            
+        self.assertGreater(stats['no'], stats['yes'])
+        self.assertAlmostEqual(stats['no']/float(N), 0.7, places=1)
+        self.assertAlmostEqual(stats['yes']/float(N), 0.3, places=1)
+        


### PR DESCRIPTION
This PR allows non-uniform alternatives allocation (i.e. 70/30, 60/40, etc).

In order to use the existing interface and being backward compatible, I have "embedded" the allocation percentage within the alternative name.

For example, the following example will create a 70/30 experiment with two alternatives:
```
exp = Experiment("test", ["no:70", "yes:30"])
```

As far as client compatibility, we'd need to update the experiment/alternative validation regex as well, such as it includes the colon symbol:
```
VALID_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9:\-_ ]*$", re.I)
```

Eventually, we might use a valid symbol (i.e. dash) and make the weight-extraction logic slightly more complicated, so that nothing needs to change on the client. 

Thoughts?
