### PR TITLE
Fix web UI chart loading issue

### DIFF
--- a/sixpack/static/js/experiment.js
+++ b/sixpack/static/js/experiment.js
@@ -8,7 +8,7 @@ $(function () {
 
     my.el = el;
     my.codedName = name;
-    my.name = name.match(/\w+/g).join('-');
+    my.name = name.replace(/[\W_]+/g, '-');
     my.encoded = encodeURIComponent(name);
     my.callback = callback;
 


### PR DESCRIPTION
Fixes chart loading issue (#173) for experiments with underscore in their names

Handle experiment names with underscore the same way as they are rendered in template. [See 'data-experiment' attribute in details.html template](https://github.com/seatgeek/sixpack/blob/master/sixpack/templates/details.html#L131).