### PR TITLE
Add ability to send metrics to statsd

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,17 +31,20 @@ To get going, create (or don't, but you really should) a new virtualenv for your
 
 Next, create a Sixpack configuration. A configuration must be created for Sixpack to run. Here's the default::
 
-    redis_port: 6379                        # Redis port
-    redis_host: localhost                   # Redis host
-    redis_prefix: sixpack                   # all Redis keys will be prefixed with this
-    redis_db: 15                            # DB number in redis
+    redis_port: 6379                            # Redis port
+    redis_host: localhost                       # Redis host
+    redis_prefix: sixpack                       # all Redis keys will be prefixed with this
+    redis_db: 15                                # DB number in redis
+
+    metrics: false                              # send metrics to StatsD (response times, # of calls, etc)?
+    statsd_url: 'udp://localhost:8125/sixpack'  # StatsD url to connect to (used only when metrics: true)
 
     # The regex to match for robots
     robot_regex: $^|trivial|facebook|MetaURI|butterfly|google|amazon|goldfire|sleuth|xenu|msnbot|SiteUptime|Slurp|WordPress|ZIBB|ZyBorg|pingdom|bot|yahoo|slurp|java|fetch|spider|url|crawl|oneriot|abby|commentreader|twiceler
-    ignored_ip_addresses: []                # List of IP
+    ignored_ip_addresses: []                    # List of IP
 
-    asset_path: gen                         # Path for compressed assets to live. This path is RELATIVE to sixpack/static
-    secret_key: '<your secret key here>'    # Random key (any string is valid, required for sixpack-web to run)
+    asset_path: gen                             # Path for compressed assets to live. This path is RELATIVE to sixpack/static
+    secret_key: '<your secret key here>'        # Random key (any string is valid, required for sixpack-web to run)
 
 You can store this file anywhere (we recommend ``/etc/sixpack/config.yml``). As long as Redis is running, you can now start the Sixpack server like this::
 
@@ -61,6 +64,8 @@ Alternatively, as of version 1.1, all Sixpack configuration can be set by enviro
 * ``SIXPACK_CONFIG_IGNORE_IPS`` - comma separated
 * ``SIXPACK_CONFIG_ASSET_PATH``
 * ``SIXPACK_CONFIG_SECRET``
+* ``SIXPACK_METRICS``
+* ``STATSD_URL``
 
 Using the API
 =============

--- a/config.yml
+++ b/config.yml
@@ -6,9 +6,7 @@ redis_prefix: sxp
 redis_db: 15
 
 metrics: false
-statsd_host: 'localhost'
-statsd_port: 8125
-statsd_prefix: 'sixpack'
+statsd_url: 'udp://localhost:8125/sixpack'
 
 
 robot_regex: $^|trivial|facebook|MetaURI|butterfly|google|amazon|goldfire|sleuth|xenu|msnbot|SiteUptime|Slurp|WordPress|ZIBB|ZyBorg|pingdom|bot|yahoo|slurp|java|fetch|spider|url|crawl|oneriot|abby|commentreader|twiceler

--- a/config.yml
+++ b/config.yml
@@ -5,6 +5,12 @@ redis_host: localhost
 redis_prefix: sxp
 redis_db: 15
 
+metrics: false
+statsd_host: 'localhost'
+statsd_port: 8125
+statsd_prefix: 'sixpack'
+
+
 robot_regex: $^|trivial|facebook|MetaURI|butterfly|google|amazon|goldfire|sleuth|xenu|msnbot|SiteUptime|Slurp|WordPress|ZIBB|ZyBorg|pingdom|bot|yahoo|slurp|java|fetch|spider|url|crawl|oneriot|abby|commentreader|twiceler
 ignored_ip_addresses: []
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ Markdown==2.3.1
 python-coveralls==2.4.3
 gunicorn>=17.5,<=19.4.1
 gevent==1.0.2
+statsd==3.2.1

--- a/sixpack/config.py
+++ b/sixpack/config.py
@@ -30,7 +30,11 @@ else:
         'ignored_ip_addresses':os.environ.get('SIXPACK_CONFIG_IGNORE_IPS', "").split(","),
         'asset_path':os.environ.get('SIXPACK_CONFIG_ASSET_PATH', "gen"),
         'secret_key':os.environ.get('SIXPACK_CONFIG_SECRET', 'temp'),
-        'csrf_disable':os.environ.get('SIXPACK_CONFIG_CSRF_DISABLE', False)
+        'csrf_disable':os.environ.get('SIXPACK_CONFIG_CSRF_DISABLE', False),
+        'metrics': to_bool(os.environ.get('SIXPACK_METRICS', 'False')),
+        'statsd_host': os.environ.get('SIXPACK_STATSD_HOST', 'localhost'),
+        'statsd_port': int(os.environ.get('SIXPACK_STATSD_PORT', '8125')),
+        'statsd_prefix': os.environ.get('SIXPACK_STATSD_PREFIX', 'sixpack'),
     }
 
     if 'SIXPACK_CONFIG_REDIS_SENTINELS' in os.environ:

--- a/sixpack/config.py
+++ b/sixpack/config.py
@@ -32,9 +32,7 @@ else:
         'secret_key':os.environ.get('SIXPACK_CONFIG_SECRET', 'temp'),
         'csrf_disable':os.environ.get('SIXPACK_CONFIG_CSRF_DISABLE', False),
         'metrics': to_bool(os.environ.get('SIXPACK_METRICS', 'False')),
-        'statsd_host': os.environ.get('SIXPACK_STATSD_HOST', 'localhost'),
-        'statsd_port': int(os.environ.get('SIXPACK_STATSD_PORT', '8125')),
-        'statsd_prefix': os.environ.get('SIXPACK_STATSD_PREFIX', 'sixpack'),
+        'statsd_url': os.environ.get('STATSD_URL', 'udp://localhost:8125/sixpack'),
     }
 
     if 'SIXPACK_CONFIG_REDIS_SENTINELS' in os.environ:

--- a/sixpack/metrics.py
+++ b/sixpack/metrics.py
@@ -1,0 +1,8 @@
+import statsd
+
+
+def init_statsd(config):
+    host = config.get('statsd_host', 'localhost')
+    port = config.get('statsd_port', 8125)
+    prefix = config.get('statsd_prefix', 'sixpack')
+    return statsd.StatsClient(host, port, prefix=prefix)

--- a/sixpack/metrics.py
+++ b/sixpack/metrics.py
@@ -1,8 +1,8 @@
-import statsd
+from statsd import StatsClient
 
 
 def init_statsd(config):
     host = config.get('statsd_host', 'localhost')
     port = config.get('statsd_port', 8125)
     prefix = config.get('statsd_prefix', 'sixpack')
-    return statsd.StatsClient(host, port, prefix=prefix)
+    return StatsClient(host, port, prefix=prefix)

--- a/sixpack/metrics.py
+++ b/sixpack/metrics.py
@@ -1,8 +1,16 @@
+from urlparse import urlparse
 from statsd import StatsClient
 
 
+def parse_url(url):
+    parsed = urlparse(url)
+    host = parsed.hostname or 'localhost'
+    port = parsed.port or 8125
+    prefix = parsed.path[1:].replace('/', '.') or 'sixpack'
+    return (host, port, prefix)
+
+
 def init_statsd(config):
-    host = config.get('statsd_host', 'localhost')
-    port = config.get('statsd_port', 8125)
-    prefix = config.get('statsd_prefix', 'sixpack')
+    statsd_url = config.get('statsd_url', 'udp://localhost:8125/sixpack')
+    host, port, prefix = parse_url(statsd_url)
     return StatsClient(host, port, prefix=prefix)

--- a/sixpack/test/server_metrics_test.py
+++ b/sixpack/test/server_metrics_test.py
@@ -1,0 +1,56 @@
+import unittest
+import statsd
+from mock import patch, call
+
+from werkzeug.test import Client
+from werkzeug.wrappers import BaseResponse
+
+from sixpack.config import CONFIG as cfg
+from sixpack.server import create_app
+
+
+class TestServer(unittest.TestCase):
+
+    @patch('sixpack.metrics.StatsClient', spec=statsd.StatsClient)
+    def setUp(self, statsd_client):
+        cfg['metrics'] = True
+        self.app = create_app()
+        self.client = Client(self.app, BaseResponse)
+
+    def assertMetrics(self, response_code, endpoint):
+        self.assertEqual(
+            [call('{}.count'.format(endpoint)),
+             call('response_code.{}'.format(response_code))],
+            self.app.statsd.incr.call_args_list)
+        self.app.statsd.timer.assert_called_once_with('{}.response_time'.format(endpoint))
+
+    def test_base(self):
+        self.assertEqual(200, self.client.get("/").status_code)
+        self.assertMetrics(200, 'home')
+
+    def test_404(self):
+        res = self.client.get("/i-would-walk-five-thousand-miles")
+        self.assertEqual(404, res.status_code)
+        self.app.statsd.incr.assert_called_once_with('response_code.404')
+
+    def test_participate_bad_params(self):
+        resp = self.client.get("/participate")
+        self.assertEqual(400, resp.status_code)
+        self.assertMetrics(400, 'participate')
+
+    def test_participate_ok(self):
+        resp = self.client.get("/participate?experiment=dummy&client_id=foo&alternatives=one&alternatives=two")
+        self.assertEqual(200, resp.status_code)
+        self.assertMetrics(200, 'participate')
+
+    def test_convert_bad_params(self):
+        resp = self.client.get("/convert")
+        self.assertEqual(400, resp.status_code)
+        self.assertMetrics(400, 'convert')
+
+    def test_convert_ok(self):
+        self.client.get("/participate?experiment=dummy&client_id=foo&alternatives=one&alternatives=two")
+        self.app.statsd.reset_mock()
+        resp = self.client.get("/convert?experiment=dummy&client_id=foo")
+        self.assertEqual(200, resp.status_code)
+        self.assertMetrics(200, 'convert')

--- a/sixpack/test/utils_test.py
+++ b/sixpack/test/utils_test.py
@@ -1,5 +1,6 @@
 import unittest
 from sixpack import utils
+from sixpack import metrics
 
 
 class TestServerLogic(unittest.TestCase):
@@ -34,3 +35,17 @@ class TestServerLogic(unittest.TestCase):
         self.assertFalse(utils.to_bool('FaLse'))
         self.assertFalse(utils.to_bool('no'))
         self.assertFalse(utils.to_bool('n'))
+
+
+
+class TestStatsd(unittest.TestCase):
+
+    def test_parse_url(self):
+        self.assertEqual(
+            ('example.com', 9999, 'prefix'),
+            metrics.parse_url('udp://example.com:9999/prefix'))
+
+    def test_parse_url_defaults(self):
+        self.assertEqual(
+            ('localhost', 8125, 'sixpack'),
+            metrics.parse_url(''))


### PR DESCRIPTION
This adds new option: `metrics`, which enables sending response times and number of calls for sixpack-server endpoints to statsd.

It currently sends:

- Number of calls to each endpoint
- Response time of each endpoint
- Number of responses by response code

We're using this at Urban Dictionary quite successfully and wanted to contribute back to the community if it seems appropriate and useful.

I'm happy to hear any feedback. Thanks!