### PR TITLE
add config to enable werkzeug ProxyFix middleware

### DIFF
--- a/sixpack/config.py
+++ b/sixpack/config.py
@@ -33,6 +33,7 @@ else:
         'csrf_disable':os.environ.get('SIXPACK_CONFIG_CSRF_DISABLE', False),
         'metrics': to_bool(os.environ.get('SIXPACK_METRICS', 'False')),
         'statsd_url': os.environ.get('STATSD_URL', 'udp://localhost:8125/sixpack'),
+        'proxy_fix': os.environ.get('SIXPACK_PROXY_FIX', False),
     }
 
     if 'SIXPACK_CONFIG_REDIS_SENTINELS' in os.environ:

--- a/sixpack/web.py
+++ b/sixpack/web.py
@@ -6,6 +6,7 @@ from flask.ext.seasurf import SeaSurf
 from flask.ext.assets import Environment, Bundle
 from flask_debugtoolbar import DebugToolbarExtension
 from markdown import markdown
+from werkzeug.contrib.fixers import ProxyFix
 
 from . import __version__
 from config import CONFIG as cfg
@@ -17,6 +18,8 @@ import utils
 import re
 
 app = Flask(__name__)
+if cfg.get('proxy_fix', False):
+    app.wsgi_app = ProxyFix(app.wsgi_app)
 app.config['CSRF_DISABLE'] = cfg.get('csrf_disable', False)
 
 csrf = SeaSurf(app)


### PR DESCRIPTION
Problem: 
I'm using AWS ELB with SSL in front of sixpack, all redirects go to http instead of https. 

Fix:
Use werkzeug proxy fix middleware.
