### PR TITLE
Fix from seatgeek/sixpack PR #280

### DIFF
--- a/sixpack/server.py
+++ b/sixpack/server.py
@@ -45,7 +45,7 @@ class CORSMiddleware(object):
     def __call__(self, environ, start_response):
 
         def get_origin(status, headers):
-            if self.origin == '*':
+            if self.origin == '*' or self.origin is None:
                 return self.origin
             origin = environ.get("HTTP_ORIGIN", "")
             return origin if self.origin_regexp.match(origin) else "null"


### PR DESCRIPTION
This adds the fix that is blocking the dev team from installing new instances of Sixpack. We keep running into an error with the `self.origin` being set if it is a `NoneType` object.