### PR TITLE
docs: Fix a few typos

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -147,7 +147,7 @@ Conversion Arguments
 
 - ``experiment`` (required) the name of the experiment you would like to convert on.
 - ``client_id`` (required) the client you would like to convert.
-- ``kpi`` (optional) sixpack supports recording multiple KPIs. If you would like to track conversion against a specfic KPI, you can do that here. If the KPI does not exist, it will be created automatically.
+- ``kpi`` (optional) sixpack supports recording multiple KPIs. If you would like to track conversion against a specific KPI, you can do that here. If the KPI does not exist, it will be created automatically.
 
 Notes
 -----

--- a/sixpack/models.py
+++ b/sixpack/models.py
@@ -36,7 +36,7 @@ class Experiment(object):
         self.alternatives = self.initialize_alternatives(alternatives)
         self.kpi = None
 
-        # False here is a sentinal value for "not looked up yet"
+        # False here is a sentinel value for "not looked up yet"
         self._winner = winner
         self._traffic_fraction = traffic_fraction
         self._sequential_ids = dict()


### PR DESCRIPTION
There are small typos in:
- README.rst
- sixpack/models.py

Fixes:
- Should read `specific` rather than `specfic`.
- Should read `sentinel` rather than `sentinal`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md