### PR TITLE
Travis CI: Upgrade to Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 python:
   - "2.7"
-  - "3.6"
+  - "3.8"
 install: "pip install -r requirements.txt"
 services:
   - redis-server


### PR DESCRIPTION
Python 3.6 is EOL
Python 3.8 is the last Python that supports Nose testing.